### PR TITLE
Add registered url resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -43,12 +43,12 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'guard-rspec'
+  gem 'rails-controller-testing'
   gem 'rspec-rails'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
   gem 'shoulda-matchers', '~> 5.0'
   gem 'simplecov'
-  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem 'rubocop-rspec'
   gem 'shoulda-matchers', '~> 5.0'
   gem 'simplecov'
+  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,10 @@ GEM
       activesupport (= 7.1.3.2)
       bundler (>= 1.15.0)
       railties (= 7.1.3.2)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -320,6 +324,7 @@ DEPENDENCIES
   mysql2
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
+  rails-controller-testing
   rspec-rails
   rubocop-rails
   rubocop-rspec

--- a/app/controllers/api/v1/protected_application_controller.rb
+++ b/app/controllers/api/v1/protected_application_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module V1
+    class ProtectedApplicationController < ApplicationController
+      before_action :authenticate_request
+
+      private
+
+      def authenticate_request
+        return if token && session
+
+        render json: { error: 'Unauthorized' }, status: :unauthorized
+      end
+
+      def token
+        @token ||= request.headers['Authorization']&.split(' ')&.last
+      end
+
+      def session
+        @session ||= TemporarySession.find_by(uuid: token)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/registered_urls_controller.rb
+++ b/app/controllers/api/v1/registered_urls_controller.rb
@@ -4,6 +4,22 @@ module Api
       def index
         @registered_urls = session.registered_urls.active.not_expired
       end
+
+      def create
+        @registered_url = session.registered_urls.new(registered_url_params)
+
+        unless @registered_url.valid?
+          return render json: { errors: @registered_url.errors }, status: :unprocessable_entity
+        end
+
+        @registered_url.save!
+      end
+
+      private
+
+      def registered_url_params
+        params.require(:'registered-url').permit(:url)
+      end
     end
   end
 end

--- a/app/controllers/api/v1/registered_urls_controller.rb
+++ b/app/controllers/api/v1/registered_urls_controller.rb
@@ -15,6 +15,20 @@ module Api
         @registered_url.save!
       end
 
+      def destroy
+        @registered_url = session.registered_urls.find_by(uuid: params[:id])
+        return render json: { errors: 'registered url not found' }, status: :not_found unless @registered_url
+
+        @registered_url.active = false
+        @registered_url.expires_at = Time.zone.now
+
+        unless @registered_url.valid?
+          return render json: { errors: @registered_url.errors }, status: :unprocessable_entity
+        end
+
+        @registered_url.save!
+      end
+
       private
 
       def registered_url_params

--- a/app/controllers/api/v1/registered_urls_controller.rb
+++ b/app/controllers/api/v1/registered_urls_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class RegisteredUrlsController < ProtectedApplicationController
+      def index
+        @registered_urls = session.registered_urls.active.not_expired
+      end
+    end
+  end
+end

--- a/app/models/registered_url.rb
+++ b/app/models/registered_url.rb
@@ -3,7 +3,7 @@ class RegisteredUrl < ApplicationRecord
 
   DEFAULT_EXPIRATION = 1.month
 
-  validates :url, presence: true
+  validates :url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp }
   validates :uuid, presence: true, uniqueness: true
   validates :active, inclusion: { in: [true, false] }
 

--- a/app/models/registered_url.rb
+++ b/app/models/registered_url.rb
@@ -1,5 +1,6 @@
 class RegisteredUrl < ApplicationRecord
   before_validation :generate_fields, on: :create
+  after_commit :add_expiration_date, on: :create
 
   DEFAULT_EXPIRATION = 1.month
 
@@ -18,6 +19,11 @@ class RegisteredUrl < ApplicationRecord
   def generate_fields
     self.uuid = SecureRandom.hex(3) if uuid.blank?
     self.active = true if active.nil?
-    self.expires_at = DEFAULT_EXPIRATION.from_now if expires_at.blank?
+  end
+
+  def add_expiration_date
+    return if expires_at.present?
+
+    update(expires_at: DEFAULT_EXPIRATION.from_now)
   end
 end

--- a/app/models/registered_url.rb
+++ b/app/models/registered_url.rb
@@ -1,6 +1,5 @@
 class RegisteredUrl < ApplicationRecord
   before_validation :generate_fields, on: :create
-  after_commit :add_expiration_date, on: :create
 
   DEFAULT_EXPIRATION = 1.month
 
@@ -19,11 +18,6 @@ class RegisteredUrl < ApplicationRecord
   def generate_fields
     self.uuid = SecureRandom.hex(3) if uuid.blank?
     self.active = true if active.nil?
-  end
-
-  def add_expiration_date
-    return if expires_at.present?
-
-    update(expires_at: DEFAULT_EXPIRATION.from_now)
+    self.expires_at = DEFAULT_EXPIRATION.from_now if expires_at.blank?
   end
 end

--- a/app/models/registered_url.rb
+++ b/app/models/registered_url.rb
@@ -1,21 +1,23 @@
 class RegisteredUrl < ApplicationRecord
   before_validation :generate_fields, on: :create
 
-  DEFAULT_EXPIRATION = 30.days
+  DEFAULT_EXPIRATION = 1.month
 
   validates :url, presence: true
   validates :uuid, presence: true, uniqueness: true
-  validates :expires_at, presence: true
   validates :active, inclusion: { in: [true, false] }
 
   belongs_to :temporary_session, optional: true
   has_many :url_visits, dependent: :destroy
 
+  scope :active, -> { where(active: true) }
+  scope :not_expired, -> { where('? < expires_at', Time.zone.now) }
+
   private
 
   def generate_fields
-    self.uuid = SecureRandom.hex(3) if self.uuid.blank?
-    self.active = true
-    self.expires_at = Time.zone.now + DEFAULT_EXPIRATION
+    self.uuid = SecureRandom.hex(3) if uuid.blank?
+    self.active = true if active.nil?
+    self.expires_at = DEFAULT_EXPIRATION.from_now if expires_at.blank?
   end
 end

--- a/app/views/api/v1/partials/_registered_url.json.jbuilder
+++ b/app/views/api/v1/partials/_registered_url.json.jbuilder
@@ -1,0 +1,3 @@
+json.short_version registered_url.uuid
+json.url registered_url.url
+json.expires_at registered_url.expires_at

--- a/app/views/api/v1/registered_urls/create.json.jbuilder
+++ b/app/views/api/v1/registered_urls/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.message "url shortened"
+
+json.data do
+  json.partial! 'api/v1/partials/registered_url', registered_url: @registered_url
+end

--- a/app/views/api/v1/registered_urls/destroy.json.jbuilder
+++ b/app/views/api/v1/registered_urls/destroy.json.jbuilder
@@ -1,0 +1,1 @@
+json.message 'registered url deleted'

--- a/app/views/api/v1/registered_urls/index.json.jbuilder
+++ b/app/views/api/v1/registered_urls/index.json.jbuilder
@@ -1,5 +1,3 @@
 json.array! @registered_urls do |registered_url|
-  json.short_version registered_url.uuid
-  json.url registered_url.url
-  json.expires_at registered_url.expires_at
+  json.partial! 'api/v1/partials/registered_url', registered_url:
 end

--- a/app/views/api/v1/registered_urls/index.json.jbuilder
+++ b/app/views/api/v1/registered_urls/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.array! @registered_urls do |registered_url|
+  json.short_version registered_url.uuid
+  json.url registered_url.url
+  json.expires_at registered_url.expires_at
+end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,7 @@
 # Load the Rails application.
-require_relative "application"
+require_relative 'application'
 
 # Initialize the Rails application.
+Jbuilder.key_format camelize: :lower
+Jbuilder.deep_format_keys camelize: :lower
 Rails.application.initialize!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post 'temporary-session' => 'temporary_session#create'
+      resources :registered_urls, path: 'registered-urls', only: %i[create index destroy]
     end
   end
 

--- a/db/migrate/20240401163208_change_field_at_registered_urls.rb
+++ b/db/migrate/20240401163208_change_field_at_registered_urls.rb
@@ -1,5 +1,5 @@
 class ChangeFieldAtRegisteredUrls < ActiveRecord::Migration[7.1]
   def change
-    change_column :registered_urls, :expires_at, :timestamp, null: false
+    change_column :registered_urls, :expires_at, :timestamp, null: true
   end
 end

--- a/db/migrate/20240401163208_change_field_at_registered_urls.rb
+++ b/db/migrate/20240401163208_change_field_at_registered_urls.rb
@@ -1,0 +1,5 @@
+class ChangeFieldAtRegisteredUrls < ActiveRecord::Migration[7.1]
+  def change
+    change_column :registered_urls, :expires_at, :timestamp, null: false
+  end
+end

--- a/db/migrate/20240401163208_change_field_at_registered_urls.rb
+++ b/db/migrate/20240401163208_change_field_at_registered_urls.rb
@@ -1,5 +1,5 @@
 class ChangeFieldAtRegisteredUrls < ActiveRecord::Migration[7.1]
   def change
-    change_column :registered_urls, :expires_at, :timestamp, null: true
+    change_column :registered_urls, :expires_at, :timestamp, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_29_131552) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_01_163208) do
   create_table "registered_urls", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "uuid", null: false
     t.string "url", null: false
     t.boolean "active", null: false
-    t.decimal "expires_at", precision: 10, null: false
+    t.timestamp "expires_at", null: false
     t.bigint "temporary_session_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_01_163208) do
     t.string "uuid", null: false
     t.string "url", null: false
     t.boolean "active", null: false
-    t.timestamp "expires_at", null: false
+    t.timestamp "expires_at"
     t.bigint "temporary_session_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_01_163208) do
     t.string "uuid", null: false
     t.string "url", null: false
     t.boolean "active", null: false
-    t.timestamp "expires_at"
+    t.timestamp "expires_at", null: false
     t.bigint "temporary_session_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/controllers/api/v1/registered_urls_controller_spec.rb
+++ b/spec/controllers/api/v1/registered_urls_controller_spec.rb
@@ -1,38 +1,65 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::RegisteredUrlsController, type: :controller do
-  describe 'GET #index' do
-    let(:temporary_session) { create(:temporary_session) }
+  let(:temporary_session) { create(:temporary_session) }
 
-    describe 'when is not authenticated' do
+  describe 'when is not authenticated' do
+    describe 'GET #index' do
       it 'returns unauthorized status' do
         get :index, format: :json
         expect(response).to have_http_status(:unauthorized)
       end
     end
 
-    describe 'when token is invalid' do
-      before do
-        request.headers['Authorization'] = "Token #{temporary_session.uuid}invalid"
+    describe 'POST #create' do
+      it 'returns unauthorized status' do
+        post :create, format: :json
+        expect(response).to have_http_status(:unauthorized)
       end
+    end
+  end
 
+  describe 'when token is invalid' do
+    before do
+      request.headers['Authorization'] = "Token #{temporary_session.uuid}invalid"
+    end
+
+    describe 'GET #index' do
       it 'returns unauthorized status' do
         get :index, format: :json
         expect(response).to have_http_status(:unauthorized)
       end
     end
 
-    describe 'when token is valid' do
-      before do
-        request.headers['Authorization'] = "Token #{temporary_session.uuid}"
+    describe 'POST #create' do
+      it 'returns unauthorized status' do
+        post :create, format: :json
+        expect(response).to have_http_status(:unauthorized)
       end
+    end
+  end
 
+  describe 'when token is valid' do
+    before do
+      request.headers['Authorization'] = "Token #{temporary_session.uuid}"
+    end
+
+    describe 'GET #index' do
       it 'returns success status' do
         get :index, format: :json
         expect(response).to have_http_status(:ok)
       end
     end
 
+    describe 'POST #create' do
+      it 'returns success status' do
+        post :create, params: { 'registered-url': { url: Faker::Internet.url } }, format: :json
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe 'GET #index' do
     describe 'when there are registered URLs' do
       let(:temporary_session) { create(:temporary_session) }
 
@@ -57,6 +84,40 @@ RSpec.describe Api::V1::RegisteredUrlsController, type: :controller do
       it 'returns the registered URLs' do
         get :index, format: :json
         expect(assigns(:registered_urls).count).to eq(4)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    before do
+      request.headers['Authorization'] = "Token #{temporary_session.uuid}"
+    end
+
+    describe 'when registered URL is valid' do
+      let(:params) { { 'registered-url': { url: Faker::Internet.url } } }
+
+      it 'returns ok status' do
+        post :create, params:, format: :json
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'renders expected template' do
+        post :create, params:, format: :json
+        expect(response).to render_template(:create)
+      end
+    end
+
+    describe 'when registered URL is invalid' do
+      let(:params) { { 'registered-url': { url: '/this-is.not-an-url' } } }
+
+      it 'returns unprocessable entity status' do
+        post :create, params:, format: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns the errors' do
+        post :create, params:, format: :json
+        expect(JSON.parse(response.body)).to include('errors')
       end
     end
   end

--- a/spec/controllers/api/v1/registered_urls_controller_spec.rb
+++ b/spec/controllers/api/v1/registered_urls_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::RegisteredUrlsController, type: :controller do
+  describe 'GET #index' do
+    let(:temporary_session) { create(:temporary_session) }
+
+    describe 'when is not authenticated' do
+      it 'returns unauthorized status' do
+        get :index, format: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    describe 'when token is invalid' do
+      before do
+        request.headers['Authorization'] = "Token #{temporary_session.uuid}invalid"
+      end
+
+      it 'returns unauthorized status' do
+        get :index, format: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    describe 'when token is valid' do
+      before do
+        request.headers['Authorization'] = "Token #{temporary_session.uuid}"
+      end
+
+      it 'returns success status' do
+        get :index, format: :json
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe 'when there are registered URLs' do
+      let(:temporary_session) { create(:temporary_session) }
+
+      before do
+        create_list(:registered_url, 4, temporary_session:)
+        create_list(:registered_url, 3, active: false, temporary_session:)
+        create_list(:registered_url, 2, expires_at: 40.days.ago, temporary_session:)
+
+        request.headers['Authorization'] = "Token #{temporary_session.uuid}"
+      end
+
+      it 'returns status ok' do
+        get :index, format: :json
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'renders expected template' do
+        get :index, format: :json
+        expect(response).to render_template(:index)
+      end
+
+      it 'returns the registered URLs' do
+        get :index, format: :json
+        expect(assigns(:registered_urls).count).to eq(4)
+      end
+    end
+  end
+end

--- a/spec/factories/registered_url.rb
+++ b/spec/factories/registered_url.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :registered_url do
-    url { 'https://example.com' }
+    url { Faker::Internet.url }
     active { true }
     expires_at { Time.zone.now + 30.days }
     temporary_session

--- a/spec/models/registered_url_spec.rb
+++ b/spec/models/registered_url_spec.rb
@@ -41,4 +41,28 @@ RSpec.describe RegisteredUrl, type: :model do
       expect(registered_url.url_visits_count).to eq(10)
     end
   end
+
+  describe '#active' do
+    before do
+      create(:registered_url, active: true)
+      create(:registered_url, active: true)
+      create(:registered_url, active: false)
+    end
+
+    it 'returns only active registered URLs' do
+      expect(described_class.active.count).to eq(2)
+    end
+  end
+
+  describe '#not_expired' do
+    before do
+      create(:registered_url, expires_at: 32.days.ago)
+      create(:registered_url, expires_at: 1.day.from_now)
+      create(:registered_url, expires_at: 1.day.from_now)
+    end
+
+    it 'returns only registered URLs that have not expired' do
+      expect(described_class.not_expired.count).to eq(2)
+    end
+  end
 end

--- a/spec/models/registered_url_spec.rb
+++ b/spec/models/registered_url_spec.rb
@@ -6,6 +6,17 @@ RSpec.describe RegisteredUrl, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:url) }
 
+    describe 'when validating the URL format' do
+      it 'validates the URL format' do
+        expect(registered_url).to be_valid
+      end
+
+      it 'throws an error if URL is not valid' do
+        registered_url.url = 'invalid-url'
+        expect(registered_url).not_to be_valid
+      end
+    end
+
     describe 'when creating a new RegisteredUrl' do
       it 'adds a UUID to the record' do
         expect(registered_url.uuid).to be_present


### PR DESCRIPTION
This PR 
- Modifies the `expires_at` field of `RegisteredUrl`:
  - Previously, it was a number intended for calculating the expiration date each time it was needed, which didn't make sense.
  - Now it's a date, calculated and registered upon validation of a record.
- Adds `api/v1/registered-url` registered_urls resources, with actions `index`, `create`, and `destroy`.

